### PR TITLE
Refactor/icons css

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,8 @@
       <meta charset="utf-8" />
       <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
       <link href='./styles.css' rel='stylesheet'>
-      <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200" />
+      <link href="https://fonts.googleapis.com/icon?family=Material+Icons"
+      rel="stylesheet">
       <title>ColoRandom</title>
     </head>
 <body>
@@ -20,7 +21,7 @@
     </section>
           <span>  
             <section class="buttons">
-              <button class="glow-on-hover" id="new" type="button">N E W</button>
+              <button class="glow-on-hover" id="new" type="button">NEW PALETTE</button>
               <!-- <button class="buttons" id="new">New Palette</button> -->
               <button class="glow-on-hover" id="save" type="button">S A V E</button>
               <!-- <button class="buttons" id="save">Save Palette</button> -->

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
             <section class="buttons">
               <button class="glow-on-hover" id="new" type="button">NEW PALETTE</button>
               <!-- <button class="buttons" id="new">New Palette</button> -->
-              <button class="glow-on-hover" id="save" type="button">S A V E</button>
+              <button class="glow-on-hover" id="save" type="button">SAVE PALETTE</button>
               <!-- <button class="buttons" id="save">Save Palette</button> -->
             </section>
           </span>

--- a/scripts.js
+++ b/scripts.js
@@ -15,7 +15,7 @@ var box4 = document.getElementById('box4');
 var box5 = document.getElementById('box5');
 var buttonNewPalette = document.getElementById('new');
 var buttonSavePalette = document.getElementById('save');
-var rightSection = document. querySelector('.right-section');
+var rightSection = document.querySelector('.right-section');
 var savedPalettesContainer = document.querySelector('#savedBox1');
 var boxes = document.querySelectorAll('.box');
 var colorBoxContainer = document.querySelector('.color-boxes-container');
@@ -62,9 +62,11 @@ function setRandomColor() {
     boxes[i].innerHTML = `
     <div class="box-details" id="box${i+1}" style="background-color:${allColors.colors[i].color}">
     <p class="color-hex" id="code${i}">${allColors.colors[i].color}</p>
-      <span class="material-symbols-outlined">
-      <button class="unlock-emoji"id="unlock${i+1}">🔓</button>
-      <button class="lock-emoji hidden" id="lock${i+1}">🔐</button>
+    
+      <button class="unlock-emoji"id="unlock${i+1}"><span class="material-icons md-light">
+      lock_open</span></button>
+      <button class="lock-emoji hidden" id="lock${i+1}"><span class="material-icons">
+      lock</span></button>
     </span>
   </div>`
   }
@@ -78,7 +80,9 @@ function renderRightSection() {
     <div class="mini-box-details" style="background-color:${savedPalettes[i].colors[2].color}"></div>   
     <div class="mini-box-details" style="background-color:${savedPalettes[i].colors[3].color}"></div>
     <div class="mini-box-details" style="background-color:${savedPalettes[i].colors[4].color}"></div>
-    <button class="trash-button" id="trash">🚫</button>
+    <button class="trash-button" id="trash">
+      <span class="material-icons">delete_forever</span>
+      </button>
     </section>
     `
   }

--- a/styles.css
+++ b/styles.css
@@ -3,67 +3,70 @@ html {
     height: 100%;
     width: 100%;
     flex-wrap: wrap;
-   }
-  body {
-    height: 100%;
-    width: 100%;
-    background: rgb(33,112,203);
-    background: rgb(38,38,38);
+}
+
+body {
+  height: 100%;
+  width: 100%;
+  background: rgb(33,112,203);
+  background: rgb(38,38,38);
   border: .5vmin solid;
   border-image: conic-gradient(from var(--angle), red, yellow, lime, aqua, blue, magenta, red) 1;
-  
-  animation: 10s rotate linear infinite;
-  
+  animation: 10s rotate linear infinite; 
 }
-
-
 
 @keyframes rotate {
-to {
+  to {
   --angle: 360deg;
-}
+  }
 }
 
 @property --angle {
-syntax: '<angle>';
-initial-value: 0deg;
-inherits: false;
+  syntax: '<angle>';
+  initial-value: 0deg;
+  inherits: false;
 }
 
-   
+h1 {
+  font-size: 80px;
+  padding: 8px;
+  margin: 70px;
+  color : #D1D3D4; 
+}
 
-  h1 {
-    font-size: 80px;
-    padding: 8px;
-    margin: 80px;
-    color : #D1D3D4;
-   }
-  h2 {
-    color: #D1D3D4;
-    padding: 40px;
-   }
-   .box {
+h2 {
+  color: #D1D3D4;
+  padding: 20px;
+}
+
+  .box {
     margin: 8px;
     height: 130px;
     width: 130px;
     display: flex;
     flex-direction: row;
   }
+
    #box1 {
     background-color: #0000ff;
    }
+
    #box2 {
     background-color: #ff0000;
    }
+
    #box3 {
     background-color: #ffff00;
    }
+
    #box4 {
     background-color: #ffffff;
    }
+
    #box5 {
     background-color: #ffa500;
    }
+
    .title {
     display: flex;
     flex-direction: column;
@@ -71,61 +74,62 @@ inherits: false;
     align-content: center;  
     align-items: center;
    }
+
    .color-boxes-container{
     display : flex;
     flex-direction: row;
     justify-content: space-evenly;
-    margin: 90px;
+    margin: 60px;
    }
+
    .box-colors {
     float: left;
     box-sizing: border-box;
    }
+
    .color-box {
     display: flex;
     align-items: center;
     flex-direction: column;
    }
+
   .color-hex {
     color: #D1D3D4;
     font-weight: regular;
     margin-right: 10px;
     margin-bottom: -20px;
   }
+
   .lock-emoji {
     font-size: 20px;
+    color: white;
     background: transparent;
     border: transparent;
   }
+
   .trash-button {
-    font-size: 20px;
+    font-size: 22px;
   }
+
   .unlock-emoji {
     font-size: 20px;
     background: transparent;
     border: transparent;
   }
 
-  /* .material-symbols-rounded {
-    font-variation-settings:
-    'FILL' 0,
-    'wght' 400,
-    'GRAD' 0,
-    'opsz' 48
-  } */
-
   .buttons {
-    margin-right: 245px;
+    /* margin-right: 245px; */
     display: flex;
     justify-content: center;
     align-items: center;
-    margin: 65px;
+    margin: 10px;
     /* font-style: italic; */
     font-weight: bold;
     font-size: 22pt;
   }
+
  .right-section {
-    float: right;
+    float: left;
     width: 230px;
     height: 100%;
     background-color: rgba(255, 255, 255, 0);
@@ -133,44 +137,48 @@ inherits: false;
     padding: 33px;
     margin-right: 0px
   }
+
  main {
     flex: 70% ;
     display: flex;
     justify-content: center;
   }
+
  .wrapper1 {
     display: flex;
     align-items: baseline;
     flex-direction: column;
     justify-content: space-evenly;
   }
+
  .wrapper2 {
     display: flex;
     justify-content: center;
-    float: right;
-    margin-right: -41px;
+    float: left;
   }
+
  .box-details {
     display: flex;
     justify-content: space-around;
     align-items: flex-end;
     width: 132px
   }
+
   .mini-palette {
     margin-top: 8px;
     display: flex;
     justify-content: space-around;
   }
+
   .mini-box-details {
     margin: 1.2px;
-    height: 52px;
-    width: 52px;
+    height: 51px;
+    width: 51px;
   }
- .hidden {
-    display : none;
-  }
-  
 
+ .hidden {
+    display: none;
+  }
 
 .glow-on-hover {
     width: 220px;
@@ -187,9 +195,7 @@ inherits: false;
     justify-content: center;
     align-items: center;
     margin: 43px;
-    /* font-style: italic; */
-    font-weight: regular;
-    
+    font-weight: regular; 
 }
 
 .glow-on-hover:before {
@@ -209,17 +215,13 @@ inherits: false;
     border-radius: 10px;
 }
 
-
-
 /* GLOW BUTTONS */
 .glow-on-hover:active {
-    color: #101010
-    
+    color: #101010 
 }
 
 .glow-on-hover:active:after {
-    background: transparent;
-    
+    background: transparent;  
 }
 
 .glow-on-hover:hover:before {
@@ -235,7 +237,7 @@ inherits: false;
     background: #111;
     left: 0;
     top: 0;
-    border-radius: 10px;
+    border-radius: 20px;
 }
 
 @keyframes glowing {

--- a/styles.css
+++ b/styles.css
@@ -80,6 +80,7 @@ h2 {
     flex-direction: row;
     justify-content: space-evenly;
     margin: 60px;
+    cursor: pointer;
    }
 
    .box-colors {
@@ -109,6 +110,7 @@ h2 {
 
   .trash-button {
     font-size: 22px;
+    cursor: pointer;
   }
 
   .unlock-emoji {


### PR DESCRIPTION
This branch:
-refactors some of the CSS 
-inserts new icons for the locks and trashcan using google material icons. The new locks are black when unlocked and white when locked. They remain on the blocks of color. 

To consider as we continue refactoring tomorrow:
-the event.target for the trash buttons which uses the className 'trash-button' only activates delete when around the icon of the trash can. Only the trash button will delete a palate, not the icon on the trash button. 
-more css could be deleted, seems redundant: we currently have several selectors for buttons, the color boxes, and the right hand side of the page. 


![image](https://user-images.githubusercontent.com/117617970/211230217-8b9c24b8-ccaa-4c3c-a493-3060731c1c92.png)

